### PR TITLE
update Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,25 @@
+sudo: false
+
 language: php
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files
 
 php:
   - 5.5
   - 5.6
   - 7.0
+  
+matrix:
+  fast_finish: true
+  include:
+    - php: 7.0
+      env: deps=low
 
 before_script:
-  - composer install --prefer-dist
+  - phpenv config-rm xdebug.ini
+  - if [[ "$deps" = "low" ]]; then composer update --prefer-lowest --prefer-stable; else composer install --prefer-dist; fi
 
 script:
   - ./vendor/bin/phpspec run


### PR DESCRIPTION
- use faster container based infrastructure
- cache downloaded package archives
- report build results as soon as possible
- add dedicated job with lowest allowed dependencies
- disable the Xdebug extension to speed up builds
